### PR TITLE
Disable io buffering when logging to stdout

### DIFF
--- a/lib/mail_room/mailbox.rb
+++ b/lib/mail_room/mailbox.rb
@@ -213,6 +213,8 @@ module MailRoom
       when nil, ""
         nil
       when :stdout, "STDOUT"
+        # if we're logging to stdout, disable buffering
+        $stdout.sync = true
         STDOUT
       when :stderr, "STDERR"
         STDERR


### PR DESCRIPTION
Should prevent batching of log output, which can result in logging delays and having CloudWatch assign the same timestamp for up to 50 output lines.